### PR TITLE
Improve regex from sending non-hex characters

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -13,7 +13,7 @@ document.addEventListener("mouseup", function (e) {
         return;
     }
 
-    var purchase_code_pattern = /\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/;
+    var purchase_code_pattern = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
     if (!purchase_code_pattern.test(selection)) {
         var length = selection.length;


### PR DESCRIPTION
`\w` includes the characters `a-z`, `A-Z`, `0-9` and `_`. In it's
current form, highlighting the string
`________-____-____-____-____________` sends the API request even
though it isn't a valid purchase code.

This fixes it by updating the regular expression to only allow hex
characters used in the purchase codes.